### PR TITLE
add raw() method

### DIFF
--- a/lib/Mojo/PDF.pm
+++ b/lib/Mojo/PDF.pm
@@ -167,6 +167,12 @@ sub page {
     $self;
 }
 
+sub raw {
+    my $self = shift;
+    prAdd shift;
+    $self;
+}
+
 sub rule {
     my ( $self, %new ) = @_;
     my $rules = $self->_rules;
@@ -436,6 +442,15 @@ which defaults to the first page.
     $pdf->page;
 
 Add a new blank page to your document and sets it as the currently active page.
+
+=head2 C<raw>
+
+    $pdf->raw("0 0 m\n10 10 l\nS\nh\n");
+
+Use L<prAdd|PDF::Reuse/"prAdd"> to "add whatever you want to the current content stream".
+
+See, for example, section 4.4.1 on page 196 of the
+L<Adobe Acrobat SDK PDF Reference Manual|https://web.archive.org/web/20060212001631/http://partners.adobe.com/public/developer/en/acrobat/sdk/pdf/pdf_creation_apis_and_specs/PDFReference.pdf>.
 
 =head2 C<rule>
 


### PR DESCRIPTION
I'm *really* finding benefit in Mojo::PDF!  One function that would be really helpful to have is the low-level `prAdd` function from PDF::Reuse.  I called the Mojo::PDF method `raw`.  LMK if you'd prefer something more similar to the original function name.  Also, of high importance, is a link to the PDF Reference Manual.  So far, I haven't been able to find a copy on Adobe's website to link to, but I found a copy of an older version on the wayback machine.  Do you think it's OK to link to that?  The `prAdd` function in PDF::Reuse gives a URL that's now 404, and mentions that this reference manual is pretty much necessary to use the function, so I found it pretty necessary to link to something usable.

What reference manual did you use when calling `prAdd` directly?